### PR TITLE
Feature add repair requests

### DIFF
--- a/scripts/components/RepairRequest.jsx
+++ b/scripts/components/RepairRequest.jsx
@@ -7,78 +7,7 @@ var DatePicker = mui.DatePicker;
 var TextField = mui.TextField;
 var RaisedButton = mui.RaisedButton;
 var Paper = mui.Paper;
-
-var RepairRequestAdd = React.createClass({
-  getInitialState() {
-    return {
-      subject: '', // user entered subject
-      description: '', // user entered description
-      image: '' // user entered image
-    }
-  },
-  // Capture the input field state after each keypress.
-  onChange(field, event) {
-    this.setState({ [field]: event.target.value });
-  },
-  // Handle the form submission event when the user tries to log in.
-  onSubmit(event) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    Api.addRepairRequest({
-      data: {
-        date: this.state.date,
-        subject: this.state.subject,
-        description: this.state.description,
-        image: this.state.image
-      },
-      callback: (err, response) => {
-        if (err) {
-          return;
-        }
-
-      // TODO: After submit, clear form and refresh module
-        
-      }
-    });
-  },
-  render() {
-    var { subject, description, image } = this.state;
-    var errorMessage;
-    var currentDate = new Date();
-    return (
-      <div style={style.formContainer}>
-        <h2 style={style.heading}>Add a Repair Request</h2>
-        <Paper zDepth={1}>  
-          <form style={style.form} onSubmit={this.onSubmit}>
-            <div style={style.error}> { errorMessage } </div>
-            <DatePicker
-              name="Date"
-              //TODO: set default date, changing date with selected date
-              onChange={this._handleChange} 
-              floatingLabelText="Date"/>
-            <TextField
-              value={subject}
-              name="Subject"
-              onChange={this.onChange.bind(this, 'subject')}
-              floatingLabelText="Subject" />
-            <TextField
-              value={description}
-              name="Description"
-              onChange={this.onChange.bind(this, 'description')}
-              floatingLabelText="Description" />
-            <TextField
-              value={image}
-              name="Image"
-              onChange={this.onChange.bind(this, 'image')}
-              floatingLabelText="Image" />
-            <RaisedButton type="submit" label="Submit" primary={true} backgroundColor="#2ECC71" style={style.button} />
-          </form>
-        </Paper>
-      </div>
-    );
-  }
-});
+var RepairRequestForm = require('./RepairRequestForm.jsx');
 
 var RepairRequest = React.createClass({
   getInitialState() {
@@ -87,7 +16,7 @@ var RepairRequest = React.createClass({
     };
   },
 
-  componentWillMount() {
+  getRepairRequests() {
     Api.getRepairRequests({
       callback: (err, response) => {
         if (err) {
@@ -100,6 +29,10 @@ var RepairRequest = React.createClass({
         });
       }
     });
+  },
+
+  componentWillMount() {
+    this.getRepairRequests()
   },
 
   render() {
@@ -127,7 +60,7 @@ var RepairRequest = React.createClass({
           </tr>
           {rows}
         </table>
-        <RepairRequestAdd />
+        <RepairRequestForm newDataAdded={this.getRepairRequests}/>
       </div>
     );
   }

--- a/scripts/components/RepairRequest.jsx
+++ b/scripts/components/RepairRequest.jsx
@@ -40,11 +40,11 @@ var RepairRequest = React.createClass({
 
     var rows = repairRequests.map(request => {
       return (
-        <tr key={request.date}>
+        <tr key={request.id}>
           <td>{moment(request.date).format('Do MMM YYYY')}</td>
-          <td>{request.subject}</td>
           <td>{request.request}</td>
           <td><img src={request.photo} /></td>
+          <td>{request.status}</td>
         </tr>
       );
     });
@@ -54,9 +54,9 @@ var RepairRequest = React.createClass({
         <table>
           <tr>
             <th>Date</th>
-            <th>Subject</th>
             <th>Description</th>
             <th>Image</th>
+            <th>Status</th>
           </tr>
           {rows}
         </table>

--- a/scripts/components/RepairRequest.jsx
+++ b/scripts/components/RepairRequest.jsx
@@ -1,6 +1,84 @@
 var React = require('react');
 var moment = require('moment');
 var Api = require('../utils/Api.js');
+var MuiContextified = require('./MuiContextified.jsx');
+var mui = require('material-ui');
+var DatePicker = mui.DatePicker;
+var TextField = mui.TextField;
+var RaisedButton = mui.RaisedButton;
+var Paper = mui.Paper;
+
+var RepairRequestAdd = React.createClass({
+  getInitialState() {
+    return {
+      subject: '', // user entered subject
+      description: '', // user entered description
+      image: '' // user entered image
+    }
+  },
+  // Capture the input field state after each keypress.
+  onChange(field, event) {
+    this.setState({ [field]: event.target.value });
+  },
+  // Handle the form submission event when the user tries to log in.
+  onSubmit(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    Api.addRepairRequest({
+      data: {
+        date: this.state.date,
+        subject: this.state.subject,
+        description: this.state.description,
+        image: this.state.image
+      },
+      callback: (err, response) => {
+        if (err) {
+          return;
+        }
+
+      // TODO: After submit, clear form and refresh module
+        
+      }
+    });
+  },
+  render() {
+    var { subject, description, image } = this.state;
+    var errorMessage;
+    var currentDate = new Date();
+    return (
+      <div style={style.formContainer}>
+        <h2 style={style.heading}>Add a Repair Request</h2>
+        <Paper zDepth={1}>  
+          <form style={style.form} onSubmit={this.onSubmit}>
+            <div style={style.error}> { errorMessage } </div>
+            <DatePicker
+              name="Date"
+              //TODO: set default date, changing date with selected date
+              onChange={this._handleChange} 
+              floatingLabelText="Date"/>
+            <TextField
+              value={subject}
+              name="Subject"
+              onChange={this.onChange.bind(this, 'subject')}
+              floatingLabelText="Subject" />
+            <TextField
+              value={description}
+              name="Description"
+              onChange={this.onChange.bind(this, 'description')}
+              floatingLabelText="Description" />
+            <TextField
+              value={image}
+              name="Image"
+              onChange={this.onChange.bind(this, 'image')}
+              floatingLabelText="Image" />
+            <RaisedButton type="submit" label="Submit" primary={true} backgroundColor="#2ECC71" style={style.button} />
+          </form>
+        </Paper>
+      </div>
+    );
+  }
+});
 
 var RepairRequest = React.createClass({
   getInitialState() {
@@ -44,11 +122,12 @@ var RepairRequest = React.createClass({
           <tr>
             <th>Date</th>
             <th>Subject</th>
-            <th>Request</th>
+            <th>Description</th>
             <th>Image</th>
           </tr>
           {rows}
         </table>
+        <RepairRequestAdd />
       </div>
     );
   }
@@ -59,7 +138,16 @@ var style = {
     display: 'flex',
     flexDirection: 'column',
     padding: '20px',
-  }
+  },
+  formContainer: {
+    width: '325px',
+  },
+  form: {
+    display: 'flex',
+    padding: '2em',
+    flexDirection: 'column',
+    maxWidth: '20em',
+  },
 };
 
-module.exports = RepairRequest;
+module.exports = MuiContextified(RepairRequest);

--- a/scripts/components/RepairRequest.jsx
+++ b/scripts/components/RepairRequest.jsx
@@ -13,6 +13,7 @@ var RepairRequest = React.createClass({
   getInitialState() {
     return {
       repairRequests: [], // list of repair requests
+      isFormDisplayed: false,
     };
   },
 
@@ -31,19 +32,27 @@ var RepairRequest = React.createClass({
     });
   },
 
+  onButtonClick() {
+    this.setState({ isFormDisplayed: true });
+  },
+
   componentWillMount() {
     this.getRepairRequests()
   },
 
   render() {
-    var { repairRequests } = this.state;
+    var { repairRequests, isFormDisplayed } = this.state;
 
     var rows = repairRequests.map(request => {
       return (
         <tr key={request.id}>
           <td>{moment(request.date).format('Do MMM YYYY')}</td>
           <td>{request.request}</td>
-          <td><img src={request.photo} /></td>
+          <td>
+            {request.photo ?
+              ( <img src={request.photo} /> ) :
+              ( <i>No image added</i> )}
+          </td>
           <td>{request.status}</td>
         </tr>
       );
@@ -60,7 +69,15 @@ var RepairRequest = React.createClass({
           </tr>
           {rows}
         </table>
-        <RepairRequestForm newDataAdded={this.getRepairRequests}/>
+        <div style={style.formContainer}>
+          { isFormDisplayed ? (
+            <RepairRequestForm repairRequestAdded={this.getRepairRequests}/>
+          ) : (
+            <RaisedButton label="Lodge a New Repair Request"
+                          primary={true}
+                          onClick={this.onButtonClick} />
+          )}
+        </div>
       </div>
     );
   }
@@ -73,7 +90,7 @@ var style = {
     padding: '20px',
   },
   formContainer: {
-    width: '325px',
+    marginTop: '1em'
   },
   form: {
     display: 'flex',

--- a/scripts/components/RepairRequestForm.jsx
+++ b/scripts/components/RepairRequestForm.jsx
@@ -1,0 +1,119 @@
+var React = require('react');
+var moment = require('moment');
+var Api = require('../utils/Api.js');
+var MuiContextified = require('./MuiContextified.jsx');
+var mui = require('material-ui');
+var DatePicker = mui.DatePicker;
+var TextField = mui.TextField;
+var RaisedButton = mui.RaisedButton;
+var Paper = mui.Paper;
+
+var RepairRequestForm = React.createClass({
+  getInitialState() {
+    return {
+      subject: '', // User entered subject
+      description: '', // User entered description
+      image: '', // user entered image
+    }
+  },
+
+  propTypes: {
+        newDataAdded:   React.PropTypes.func,
+  },
+
+  // Capture the input field state after each keypress.
+  onChange(field, event) {
+    this.setState({ [field]: event.target.value });
+  },
+
+  // Handle the form submission event when the user adds new repair request.
+  onSubmit(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // API call to add repair request
+    Api.addRepairRequest({
+      data: {
+        date: this.refs.DatePicker.getDate(),
+        subject: this.state.subject,
+        description: this.state.description,
+        image: this.state.image
+      },
+      callback: (err, response) => {
+        if (err) {
+          return;
+        }
+        // Clear the form
+        this.setState({
+          subject: "",
+          description: "",
+          image: ""
+        });
+        // Refetch repair requests via props
+        this.props.newDataAdded();
+      }
+    });
+  },
+
+  render() {
+    var { subject, description, image } = this.state;
+    var errorMessage;
+    var currentDate = new Date();
+    return (
+      <div style={style.formContainer}>
+        <h2 style={style.heading}>Add a Repair Request</h2>
+        <Paper zDepth={1}>
+          <form style={style.form} onSubmit={this.onSubmit}>
+            <div style={style.error}> { errorMessage } </div>
+            <DatePicker
+              name="Date"
+              ref="DatePicker"
+              //TODO: set default date, changing date with selected date
+              onChange={this._handleChange}
+              floatingLabelText="Date"/>
+            <TextField
+              value={subject}
+              name="Subject"
+              onChange={this.onChange.bind(this, 'subject')}
+              floatingLabelText="Subject" />
+            <TextField
+              value={description}
+              name="Description"
+              onChange={this.onChange.bind(this, 'description')}
+              floatingLabelText="Description" />
+            <TextField
+              value={image}
+              name="Image"
+              onChange={this.onChange.bind(this, 'image')}
+              floatingLabelText="Image" />
+            <RaisedButton
+              type="submit"
+              label="Submit"
+              primary={true}
+              backgroundColor="#2ECC71"
+              style={style.button} />
+          </form>
+        </Paper>
+      </div>
+    );
+  }
+});
+
+var style = {
+  page: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '20px',
+  },
+  formContainer: {
+    width: '325px',
+  },
+  form: {
+    display: 'flex',
+    padding: '2em',
+    flexDirection: 'column',
+    maxWidth: '20em',
+  },
+};
+
+module.exports = MuiContextified(RepairRequestForm);

--- a/scripts/components/RepairRequestForm.jsx
+++ b/scripts/components/RepairRequestForm.jsx
@@ -11,7 +11,6 @@ var Paper = mui.Paper;
 var RepairRequestForm = React.createClass({
   getInitialState() {
     return {
-      subject: '', // User entered subject
       description: '', // User entered description
       image: '', // user entered image
     }
@@ -34,8 +33,6 @@ var RepairRequestForm = React.createClass({
     // API call to add repair request
     Api.addRepairRequest({
       data: {
-        date: this.refs.DatePicker.getDate(),
-        subject: this.state.subject,
         description: this.state.description,
         image: this.state.image
       },
@@ -45,7 +42,6 @@ var RepairRequestForm = React.createClass({
         }
         // Clear the form
         this.setState({
-          subject: "",
           description: "",
           image: ""
         });
@@ -56,26 +52,14 @@ var RepairRequestForm = React.createClass({
   },
 
   render() {
-    var { subject, description, image } = this.state;
+    var { description, image } = this.state;
     var errorMessage;
-    var currentDate = new Date();
     return (
       <div style={style.formContainer}>
         <h2 style={style.heading}>Add a Repair Request</h2>
         <Paper zDepth={1}>
           <form style={style.form} onSubmit={this.onSubmit}>
             <div style={style.error}> { errorMessage } </div>
-            <DatePicker
-              name="Date"
-              ref="DatePicker"
-              //TODO: set default date, changing date with selected date
-              onChange={this._handleChange}
-              floatingLabelText="Date"/>
-            <TextField
-              value={subject}
-              name="Subject"
-              onChange={this.onChange.bind(this, 'subject')}
-              floatingLabelText="Subject" />
             <TextField
               value={description}
               name="Description"

--- a/scripts/components/RepairRequestForm.jsx
+++ b/scripts/components/RepairRequestForm.jsx
@@ -17,7 +17,7 @@ var RepairRequestForm = React.createClass({
   },
 
   propTypes: {
-        newDataAdded:   React.PropTypes.func,
+    repairRequestAdded: React.PropTypes.func,
   },
 
   // Capture the input field state after each keypress.
@@ -46,7 +46,7 @@ var RepairRequestForm = React.createClass({
           image: ""
         });
         // Refetch repair requests via props
-        this.props.newDataAdded();
+        this.props.repairRequestAdded();
       }
     });
   },
@@ -56,12 +56,13 @@ var RepairRequestForm = React.createClass({
     var errorMessage;
     return (
       <div style={style.formContainer}>
-        <h2 style={style.heading}>Add a Repair Request</h2>
         <Paper zDepth={1}>
           <form style={style.form} onSubmit={this.onSubmit}>
+            <h3 style={style.heading}>Lodge a New Repair Request</h3>
             <div style={style.error}> { errorMessage } </div>
             <TextField
               value={description}
+              multiLine={true}
               name="Description"
               onChange={this.onChange.bind(this, 'description')}
               floatingLabelText="Description" />
@@ -72,7 +73,7 @@ var RepairRequestForm = React.createClass({
               floatingLabelText="Image" />
             <RaisedButton
               type="submit"
-              label="Submit"
+              label="Lodge Repair Request"
               primary={true}
               backgroundColor="#2ECC71"
               style={style.button} />
@@ -98,6 +99,9 @@ var style = {
     flexDirection: 'column',
     maxWidth: '20em',
   },
+  heading: {
+    margin: 0
+  }
 };
 
 module.exports = MuiContextified(RepairRequestForm);

--- a/scripts/utils/Api.js
+++ b/scripts/utils/Api.js
@@ -153,6 +153,22 @@ let Api = {
       });
   },
 
+  // Add a new repair request
+  addRepairRequest({ data={}, callback=()=>{} }) {
+    data.sender = userId;
+    axios.post(`${host}/users/${userId}/repairs`, data, {
+      withCredentials: true
+    })
+    .then((response) => {
+      callback(null, response);
+    })
+    .catch((response) => {
+      let error = response.data.errorMessage;
+      console.log(`Error in Api.addRepairRequest(): ${error}`);
+      callback(new Error(error), response);
+    });
+  },
+
   // Fetch information for a given tenants property
   getPropertyDetails({ callback=()=>{} }) {
     axios.get(`${host}/users/${userId}/property`, {


### PR DESCRIPTION
# In this PR

**Repair Requests**
- Created function for repair request calls

**Repair Requests Form**
- Created form for submitting repair requests

**API**
- Created Repair Requests API (addRepairRequest)

---
# Issues

The following issues involve further design of the application, hence I didn't go forward in making the changes.
1. Date object from DatePicker is not received by database correctly
   Currently the database 'date' for repair requests is set to TIMESTAMP. Discrepancy between frontend date payload -> actual date value in database.
2. Error occurs (Warning: flattenChildren(...): Encountered two children with the same key) when two repair requests have the same date. It appears the date is acting as a 'key' and causes only the oldest repair request to be visible (overriding the rest).

**Possible Solution**: Would it be more appropriate to assume that you cannot change the date of an initial submission of the repair request? Utilise the timestamp as the 'key'?
1. Repair Request Content
   What should actually be reported in a repair request? Date of submission (by default via database Timestamp - no payload), Type (e.g. dropdown of areas of repair - kitchen, bathroom, garage), description, date of incident?, photos, status?
